### PR TITLE
fix README, add assert, fix geometry or connect larger than expected

### DIFF
--- a/seissolxmdf/README.md
+++ b/seissolxmdf/README.md
@@ -3,21 +3,23 @@ seissolxdmf
 A python reader for SeisSol xdmf output (posix or hdf5) and hdf5 meshes.
 Below is an simple example, illustrating the use of the module:
 ```python
-import seissolxdmf as sx
+import seissolxdmf
 fn = 'test-fault.xdmf'
+# initiate class
+sx = seissolxdmf.seissolxdmf(fn)
 # Number of cells
-nElements = sx.ReadNElements(fn)
+nElements = sx.ReadNElements()
 # Read time step
-dt = sx.ReadTimeStep(fn)
+dt = sx.ReadTimeStep()
 # Read number of time steps
-ndt = sx.ReadNdt(fn)
+ndt = sx.ReadNdt()
 # load geometry array as a numpy array of shape ((nodes, 3))
-geom = sx.ReadGeometry(fn)
+geom = sx.ReadGeometry()
 # load connectivity array as a numpy array of shape ((nElements, 3 or 4))
 # The connectivity array gives for each cell a list of vertex ids.
-connect = sx.ReadConnect(fn)
+connect = sx.ReadConnect()
 # load SRs as a numpy array of shape ((ndt, nElements))
-SRs = sx.ReadData(fn, 'SRs')
+SRs = sx.ReadData('SRs')
 # load the 8th time ste of the SRs array as a numpy array of shape (nElements)
-SRs = sx.ReadData(fn, 'SRs', 8)
+SRs = sx.ReadData('SRs', 8)
 ```

--- a/seissolxmdf/README.md
+++ b/seissolxmdf/README.md
@@ -10,7 +10,7 @@ nElements = sx.ReadNElements(fn)
 # Read time step
 dt = sx.ReadTimeStep(fn)
 # Read number of time steps
-ndt = sx.ReadNElements(fn)
+ndt = sx.ReadNdt(fn)
 # load geometry array as a numpy array of shape ((nodes, 3))
 geom = sx.ReadGeometry(fn)
 # load connectivity array as a numpy array of shape ((nElements, 3 or 4))

--- a/seissolxmdf/seissolxdmf/__init__.py
+++ b/seissolxmdf/seissolxdmf/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmf import *
-__version__ = '0.0.6'
+__version__ = '0.0.7'

--- a/seissolxmdf/seissolxdmf/__init__.py
+++ b/seissolxmdf/seissolxdmf/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmf import *
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/seissolxmdf/seissolxdmf/seissolxdmf.py
+++ b/seissolxmdf/seissolxdmf/seissolxdmf.py
@@ -3,251 +3,234 @@ import os
 import lxml.etree as ET
 
 
-def ReadHdf5DatasetChunk(absolute_path, hdf5var, firstElement, nchunk, idt=-1):
-    """ Read block of data in hdf5 format
-    idt!=-1 loads only one time step """
-    import h5py
+class seissolxdmf:
+    def __init__(self, xdmfFilename):
+        self.xdmfFilename = xdmfFilename
+        self.tree = ET.parse(xdmfFilename)
+        self.ndt = self.ReadNdt()
+        self.nElements = self.ReadNElements()
 
-    lastElement = firstElement + nchunk
+    def ReadHdf5DatasetChunk(self, absolute_path, hdf5var, firstElement, nchunk, idt=-1):
+        """ Read block of data in hdf5 format
+        idt!=-1 loads only one time step """
+        import h5py
 
-    oneDtMem = True if idt != -1 else False
-    h5f = h5py.File(absolute_path, "r")
-    if h5f[hdf5var].ndim == 2:
+        lastElement = firstElement + nchunk
+
+        oneDtMem = True if idt != -1 else False
+        h5f = h5py.File(absolute_path, "r")
+        if h5f[hdf5var].ndim == 2:
+            if oneDtMem:
+                myData = h5f[hdf5var][idt, firstElement:lastElement]
+            else:
+                myData = h5f[hdf5var][:, firstElement:lastElement]
+        else:
+            myData = h5f[hdf5var][firstElement:lastElement]
+        h5f.close()
+        return myData
+
+    def GetDtype(self, data_prec, isInt):
+        if data_prec == 4:
+            if isInt:
+                return np.dtype("i4")
+            else:
+                return np.dtype("<f")
+        else:
+            if isInt:
+                return np.dtype("i8")
+            else:
+                return np.dtype("d")
+
+    def ReadSimpleBinaryFile(self, absolute_path, MemDimension, data_prec, isInt, idt=-1):
+        """Read block of data in binary format (posix)
+        idt!=-1 loads only one time step 
+        this function is a special case of ReadSimpleBinaryFileChunk
+        but kept for performance reasons """
+        oneDtMem = True if idt != -1 else False
+        data_type = self.GetDtype(data_prec, isInt)
+
+        fid = open(absolute_path, "r")
         if oneDtMem:
-            myData = h5f[hdf5var][idt, firstElement:lastElement]
+            fid.seek(idt * MemDimension * data_prec, os.SEEK_SET)
+            myData = np.fromfile(fid, dtype=data_type, count=MemDimension)
         else:
-            myData = h5f[hdf5var][:, firstElement:lastElement]
-    else:
-        myData = h5f[hdf5var][firstElement:lastElement]
-    h5f.close()
-    return myData
+            myData = np.fromfile(fid, dtype=data_type)
+            ndt = np.shape(myData)[0] // MemDimension
+            myData = myData.reshape((ndt, MemDimension))
+        fid.close()
+        return myData
 
+    def ReadSimpleBinaryFileChunk(self, absolute_path, MemDimension, data_prec, isInt, firstElement, nchunk, idt=-1):
+        """Read block of data in binary format (posix)
+        same as ReadSimpleBinaryFile: but reads a subset of the second dimension
+        idt!=-1 loads only one time step """
+        oneDtMem = True if idt != -1 else False
+        data_type = self.GetDtype(data_prec, isInt)
 
-def GetDtype(data_prec, isInt):
-    if data_prec == 4:
-        if isInt:
-            return np.dtype("i4")
-        else:
-            return np.dtype("<f")
-    else:
-        if isInt:
-            return np.dtype("i8")
-        else:
-            return np.dtype("d")
-
-
-def ReadSimpleBinaryFile(absolute_path, MemDimension, data_prec, isInt, idt=-1):
-    """Read block of data in binary format (posix)
-    idt!=-1 loads only one time step 
-    this function is a special case of ReadSimpleBinaryFileChunk
-    but kept for performance reasons """
-    oneDtMem = True if idt != -1 else False
-    data_type = GetDtype(data_prec, isInt)
-
-    fid = open(absolute_path, "r")
-    if oneDtMem:
-        fid.seek(idt * MemDimension * data_prec, os.SEEK_SET)
-        myData = np.fromfile(fid, dtype=data_type, count=MemDimension)
-    else:
-        myData = np.fromfile(fid, dtype=data_type)
-        ndt = np.shape(myData)[0] // MemDimension
-        myData = myData.reshape((ndt, MemDimension))
-    fid.close()
-    return myData
-
-
-def ReadSimpleBinaryFileChunk(absolute_path, MemDimension, data_prec, isInt, ndt, firstElement, nchunk, idt=-1):
-    """Read block of data in binary format (posix)
-    same as ReadSimpleBinaryFile: but reads a subset of the second dimension
-    idt!=-1 loads only one time step """
-    oneDtMem = True if idt != -1 else False
-    data_type = GetDtype(data_prec, isInt)
-
-    fid = open(absolute_path, "r")
-    if oneDtMem:
-        assert idt < ndt
-        fid.seek((idt * MemDimension + firstElement) * data_prec, os.SEEK_SET)
-        myData = np.fromfile(fid, dtype=data_type, count=nchunk)
-    else:
-        myData = np.zeros((ndt, nchunk))
-        for idt in range(0, ndt):
+        fid = open(absolute_path, "r")
+        if oneDtMem:
+            assert idt < self.ndt
             fid.seek((idt * MemDimension + firstElement) * data_prec, os.SEEK_SET)
-            myData[idt, :] = np.fromfile(fid, dtype=data_type, count=nchunk)
-    fid.close()
-    return myData
-
-
-def GetDataLocationPrecisionNElementsMemDimension(xdmfFilename, attribute):
-    """ Common function called by ReadTopologyOrGeometry """
-    tree = ET.parse(xdmfFilename)
-    root = tree.getroot()
-    for Property in root.findall(".//%s" % (attribute)):
-        nElements = int(Property.get("NumberOfElements"))
-        break
-    for Property in root.findall(".//%s/DataItem" % (attribute)):
-        dataLocation = Property.text
-        data_prec = int(Property.get("Precision"))
-        MemDimension = [int(val) for val in Property.get("Dimensions").split()]
-        break
-    return [dataLocation, data_prec, nElements, MemDimension]
-
-
-def GetDataLocationPrecisionMemDimension(xdmfFilename, dataName):
-    """ Common function called by ReadData """
-
-    def get(prop):
-        dataLocation = prop.text
-        data_prec = int(prop.get("Precision"))
-        dims = prop.get("Dimensions").split()
-        if len(dims) == 1:
-            MemDimension = int(prop.get("Dimensions").split()[0])
+            myData = np.fromfile(fid, dtype=data_type, count=nchunk)
         else:
-            MemDimension = int(prop.get("Dimensions").split()[1])
-        return [dataLocation, data_prec, MemDimension]
+            myData = np.zeros((self.ndt, nchunk))
+            for idt in range(0, self.ndt):
+                fid.seek((idt * MemDimension + firstElement) * data_prec, os.SEEK_SET)
+                myData[idt, :] = np.fromfile(fid, dtype=data_type, count=nchunk)
+        fid.close()
+        return myData
 
-    tree = ET.parse(xdmfFilename)
-    root = tree.getroot()
-    for Property in root.findall(".//Attribute"):
-        if Property.get("Name") == dataName:
-            for prop in Property.findall(".//DataItem"):
-                if prop.get("Format") in ["HDF", "Binary"]:
-                    return get(prop)
-                path = prop.get("Reference")
-                if path is not None:
-                    ref = tree.xpath(path)[0]
-                    return get(ref)
-    raise NameError("%s not found in dataset" % (dataName))
+    def GetDataLocationPrecisionNElementsMemDimension(self, attribute):
+        """ Common function called by ReadTopologyOrGeometry """
+        root = self.tree.getroot()
+        for Property in root.findall(".//%s" % (attribute)):
+            nElements = int(Property.get("NumberOfElements"))
+            break
+        for Property in root.findall(".//%s/DataItem" % (attribute)):
+            dataLocation = Property.text
+            data_prec = int(Property.get("Precision"))
+            MemDimension = [int(val) for val in Property.get("Dimensions").split()]
+            break
+        return [dataLocation, data_prec, nElements, MemDimension]
 
+    def GetDataLocationPrecisionMemDimension(self, dataName):
+        """ Common function called by ReadData """
 
-def ReadTopologyOrGeometry(xdmfFilename, attribute):
-    """ Common function to read either connect or geometry """
-    path = os.path.join(os.path.dirname(xdmfFilename), "")
-    dataLocation, data_prec, nElements, MemDimension = GetDataLocationPrecisionNElementsMemDimension(xdmfFilename, attribute)
-    # 3 for surface, 4 for volume
-    dim2 = MemDimension[1]
-    splitArgs = dataLocation.split(":")
-    isHdf5 = True if len(splitArgs) == 2 else False
-    isInt = True if attribute == "Topology" else False
-    if isHdf5:
-        filename, hdf5var = splitArgs
-        myData = ReadHdf5DatasetChunk(path + filename, hdf5var, 0, dim2)
-    else:
-        myData = ReadSimpleBinaryFile(path + dataLocation, dim2, data_prec, isInt)
-        # due to zero padding in SeisSol for memory alignement, the array read may be larger than the actual data
-        myData = myData[0:nElements, :]
-    return myData
+        def get(prop):
+            dataLocation = prop.text
+            data_prec = int(prop.get("Precision"))
+            dims = prop.get("Dimensions").split()
+            if len(dims) == 1:
+                MemDimension = int(prop.get("Dimensions").split()[0])
+            else:
+                MemDimension = int(prop.get("Dimensions").split()[1])
+            return [dataLocation, data_prec, MemDimension]
 
+        root = self.tree.getroot()
+        for Property in root.findall(".//Attribute"):
+            if Property.get("Name") == dataName:
+                for prop in Property.findall(".//DataItem"):
+                    if prop.get("Format") in ["HDF", "Binary"]:
+                        return get(prop)
+                    path = prop.get("Reference")
+                    if path is not None:
+                        ref = tree.xpath(path)[0]
+                        return get(ref)
+        raise NameError("%s not found in dataset" % (dataName))
 
-def ReadConnect(xdmfFilename):
-    """ Read the connectivity matrice defining the cells """
-    return ReadTopologyOrGeometry(xdmfFilename, "Topology")
-
-
-def ReadGeometry(xdmfFilename):
-    """ Read the connectivity matrice defining the cells """
-    return ReadTopologyOrGeometry(xdmfFilename, "Geometry")
-
-
-def ReadNdt(xdmfFilename):
-    """ read number of time steps in the file """
-    tree = ET.parse(xdmfFilename)
-    root = tree.getroot()
-    ndt = 0
-    for Property in root.findall(".//Grid"):
-        if Property.get("GridType") == "Uniform":
-            ndt = ndt + 1
-    if ndt == 0:
-        raise NameError("ndt=0,( no GridType=Uniform found in xdmf)")
-    else:
-        return ndt
-
-
-def ReadNElements(xdmfFilename):
-    """ read number of cell elements of the mesh """
-    tree = ET.parse(xdmfFilename)
-    root = tree.getroot()
-    for Property in root.findall("Domain/Grid/Grid/Topology"):
-        path = Property.get("Reference")
-        if path is None:
-            return int(Property.get("NumberOfElements"))
+    def ReadTopologyOrGeometry(self, attribute):
+        """ Common function to read either connect or geometry """
+        path = os.path.join(os.path.dirname(self.xdmfFilename), "")
+        dataLocation, data_prec, nElements, MemDimension = self.GetDataLocationPrecisionNElementsMemDimension(attribute)
+        # 3 for surface, 4 for volume
+        dim2 = MemDimension[1]
+        splitArgs = dataLocation.split(":")
+        isHdf5 = True if len(splitArgs) == 2 else False
+        isInt = True if attribute == "Topology" else False
+        if isHdf5:
+            filename, hdf5var = splitArgs
+            myData = self.ReadHdf5DatasetChunk(path + filename, hdf5var, 0, dim2)
         else:
-            ref = tree.xpath(path)[0]
-            return int(ref.get("NumberOfElements"))
-    raise NameError("nElements could not be determined")
+            myData = self.ReadSimpleBinaryFile(path + dataLocation, dim2, data_prec, isInt)
+            # due to zero padding in SeisSol for memory alignement, the array read may be larger than the actual data
+            myData = myData[0:nElements, :]
+        return myData
 
+    def ReadConnect(self):
+        """ Read the connectivity matrice defining the cells """
+        return self.ReadTopologyOrGeometry("Topology")
 
-def ReadTimeStep(xdmfFilename):
-    """ reading the time step (dt) in the xdmf file """
-    tree = ET.parse(xdmfFilename)
-    root = tree.getroot()
-    i = 0
-    for Property in root.findall("Domain/Grid/Grid/Time"):
-        if i == 0:
-            dt = float(Property.get("Value"))
-            i = 1
+    def ReadGeometry(self):
+        """ Read the connectivity matrice defining the cells """
+        return self.ReadTopologyOrGeometry("Geometry")
+
+    def ReadNdt(self):
+        """ read number of time steps in the file """
+        root = self.tree.getroot()
+        ndt = 0
+        for Property in root.findall(".//Grid"):
+            if Property.get("GridType") == "Uniform":
+                ndt = ndt + 1
+        if ndt == 0:
+            raise NameError("ndt=0,( no GridType=Uniform found in xdmf)")
         else:
-            dt = float(Property.get("Value")) - dt
-            return dt
-    raise NameError("time step could not be determined")
+            return ndt
 
+    def ReadNElements(self):
+        """ read number of cell elements of the mesh """
+        root = self.tree.getroot()
+        for Property in root.findall("Domain/Grid/Grid/Topology"):
+            path = Property.get("Reference")
+            if path is None:
+                return int(Property.get("NumberOfElements"))
+            else:
+                ref = tree.xpath(path)[0]
+                return int(ref.get("NumberOfElements"))
+        raise NameError("nElements could not be determined")
 
-def Read1dData(xdmfFilename, dataName, nElements, isInt=False):
-    """ Read 1 dimension array (used by ReadPartition) """
-    path = os.path.join(os.path.dirname(xdmfFilename), "")
-    dataLocation, data_prec, MemDimension = GetDataLocationPrecisionMemDimension(xdmfFilename, dataName)
-    splitArgs = dataLocation.split(":")
-    isHdf5 = True if len(splitArgs) == 2 else False
-    if isHdf5:
-        filename, hdf5var = splitArgs
-        myData = ReadHdf5DatasetChunk(path + filename, hdf5var, 0, MemDimension)
-    else:
-        filename = dataLocation
-        myData = ReadSimpleBinaryFile(path + dataLocation, nElements, data_prec, isInt)
-    return myData
+    def ReadTimeStep(self):
+        """ reading the time step (dt) in the xdmf file """
+        root = self.tree.getroot()
+        i = 0
+        for Property in root.findall("Domain/Grid/Grid/Time"):
+            if i == 0:
+                dt = float(Property.get("Value"))
+                i = 1
+            else:
+                dt = float(Property.get("Value")) - dt
+                return dt
+        raise NameError("time step could not be determined")
 
+    def Read1dData(self, dataName, nElements, isInt=False):
+        """ Read 1 dimension array (used by ReadPartition) """
+        path = os.path.join(os.path.dirname(self.xdmfFilename), "")
+        dataLocation, data_prec, MemDimension = self.GetDataLocationPrecisionMemDimension(dataName)
+        splitArgs = dataLocation.split(":")
+        isHdf5 = True if len(splitArgs) == 2 else False
+        if isHdf5:
+            filename, hdf5var = splitArgs
+            myData = self.ReadHdf5DatasetChunk(path + filename, hdf5var, 0, MemDimension)
+        else:
+            filename = dataLocation
+            myData = self.ReadSimpleBinaryFile(path + dataLocation, nElements, data_prec, isInt)
+        return myData
 
-def ReadPartition(xdmfFilename):
-    """ Read partition array """
-    nElements = ReadNElements(xdmfFilename)
-    partition = Read1dData(xdmfFilename, "partition", nElements, isInt=True)
-    return partition
+    def ReadPartition(self):
+        """ Read partition array """
+        partition = self.Read1dData("partition", self.nElements, isInt=True)
+        return partition
 
+    def ReadData(self, dataName, idt=-1):
+        """ Load a data array named 'dataName' (e.g. SRs)
+        if idt!=-1, only the time step idt is loaded
+        else all time steps are loaded   """
 
-def ReadData(xdmfFilename, dataName, idt=-1):
-    """ Load a data array named 'dataName' (e.g. SRs)
-    if idt!=-1, only the time step idt is loaded
-    else all time steps are loaded   """
+        return self.ReadDataChunk(dataName, firstElement=0, nchunk=self.nElements, idt=idt)
 
-    nElements = ReadNElements(xdmfFilename)
-    return ReadDataChunk(xdmfFilename, dataName, firstElement=0, nchunk=nElements, idt=idt)
+    def ReadDataChunk(self, dataName, firstElement, nchunk, idt=-1):
+        """ Load a chunk of a data array named 'dataName' (e.g. SRs)
+        That is instead of loading 0:nElements, load firstElement:firstElement+nchunk
+        This function is used for generating in parallel Ground motion estimate maps
+        if idt!=-1, only the time step idt is loaded
+        else all time steps are loaded   """
+        path = os.path.join(os.path.dirname(self.xdmfFilename), "")
+        dataLocation, data_prec, MemDimension = self.GetDataLocationPrecisionMemDimension(dataName)
+        splitArgs = dataLocation.split(":")
+        isHdf5 = True if len(splitArgs) == 2 else False
+        oneDtMem = True if idt != -1 else False
+        if isHdf5:
+            filename, hdf5var = splitArgs
+            myData = self.ReadHdf5DatasetChunk(path + filename, hdf5var, firstElement, nchunk, idt)
+        else:
+            myData = self.ReadSimpleBinaryFileChunk(path + dataLocation, MemDimension, data_prec, isInt=False, firstElement=firstElement, nchunk=nchunk, idt=idt)
+        return myData
 
-
-def ReadDataChunk(xdmfFilename, dataName, firstElement, nchunk, idt=-1):
-    """ Load a chunk of a data array named 'dataName' (e.g. SRs)
-    That is instead of loading 0:nElements, load firstElement:firstElement+nchunk
-    This function is used for generating in parallel Ground motion estimate maps
-    if idt!=-1, only the time step idt is loaded
-    else all time steps are loaded   """
-    path = os.path.join(os.path.dirname(xdmfFilename), "")
-    dataLocation, data_prec, MemDimension = GetDataLocationPrecisionMemDimension(xdmfFilename, dataName)
-    splitArgs = dataLocation.split(":")
-    isHdf5 = True if len(splitArgs) == 2 else False
-    oneDtMem = True if idt != -1 else False
-    if isHdf5:
-        filename, hdf5var = splitArgs
-        myData = ReadHdf5DatasetChunk(path + filename, hdf5var, firstElement, nchunk, idt)
-    else:
-        ndt = ReadNdt(xdmfFilename)
-        myData = ReadSimpleBinaryFileChunk(path + dataLocation, MemDimension, data_prec, isInt=False, ndt=ndt, firstElement=firstElement, nchunk=nchunk, idt=idt)
-    return myData
-
-
-def LoadData(xdmfFilename, dataName, nElements, idt=0, oneDtMem=False, firstElement=-1):
-    """ Do the same as ReadDataChunk. here for backward compatibility """
-    dataLocation, data_prec, MemDimension = GetDataLocationPrecisionMemDimension(xdmfFilename, dataName)
-    if not oneDtMem:
-        idt = -1
-    if firstElement == -1:
-        firstElement = 0
-    myData = ReadDataChunk(xdmfFilename, dataName, firstElement, nElements, idt)
-    return [myData, data_prec]
+    def LoadData(self, dataName, nElements, idt=0, oneDtMem=False, firstElement=-1):
+        """ Do the same as ReadDataChunk. here for backward compatibility """
+        dataLocation, data_prec, MemDimension = self.GetDataLocationPrecisionMemDimension(dataName)
+        if not oneDtMem:
+            idt = -1
+        if firstElement == -1:
+            firstElement = 0
+        myData = ReadDataChunk(dataName, firstElement, nElements, idt)
+        return [myData, data_prec]

--- a/seissolxmdf/seissolxdmf/seissolxdmf.py
+++ b/seissolxmdf/seissolxdmf/seissolxdmf.py
@@ -65,6 +65,7 @@ def ReadSimpleBinaryFileChunk(absolute_path, MemDimension, data_prec, isInt, ndt
 
     fid = open(absolute_path, "r")
     if oneDtMem:
+        assert idt < ndt
         fid.seek((idt * MemDimension + firstElement) * data_prec, os.SEEK_SET)
         myData = np.fromfile(fid, dtype=data_type, count=nchunk)
     else:
@@ -132,7 +133,8 @@ def ReadTopologyOrGeometry(xdmfFilename, attribute):
         myData = ReadHdf5DatasetChunk(path + filename, hdf5var, 0, dim2)
     else:
         myData = ReadSimpleBinaryFile(path + dataLocation, dim2, data_prec, isInt)
-        myData = myData.reshape((nElements, dim2))
+        # due to zero padding in SeisSol for memory alignement, the array read may be larger than the actual data
+        myData = myData[0:nElements, :]
     return myData
 
 


### PR DESCRIPTION
When using the module, I got some unexpected behavior when reading the geometry and connect of the following file:

```
<?xml version="1.0" ?>
<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
<Xdmf Version="2.0">
 <Domain>
  <Grid Name="TimeSeries" GridType="Collection" CollectionType="Temporal">
   <Grid Name="step_000000000000" GridType="Uniform"><!-- mesh id: 0, mesh step: 0 -->
    <Topology TopologyType="Triangle" NumberOfElements="28240">
     <DataItem NumberType="Int" Precision="8" Format="Binary" Dimensions="28240 3">tpv24-surface_cell/mesh0/connect.bin</DataItem>
    </Topology>
    <Geometry name="geo" GeometryType="XYZ" NumberOfElements="84720">
     <DataItem NumberType="Float" Precision="8" Format="Binary" Dimensions="84720 3">tpv24-surface_vertex/mesh0/geometry.bin</DataItem>
    </Geometry>
    <Time Value="0"/>
    <Attribute Name="partition" Center="Cell">
     <DataItem  NumberType="Int" Precision="4" Format="Binary" Dimensions="28240">tpv24-surface_cell/mesh0/partition.bin</DataItem>
    </Attribute>
    <Attribute Name="u" Center="Cell">
     <DataItem ItemType="HyperSlab" Dimensions="28240">
      <DataItem NumberType="UInt" Precision="4" Format="XML" Dimensions="3 2">0 0 1 1 1 28240</DataItem>
      <DataItem NumberType="Float" Precision="8" Format="Binary" Dimensions="1 1048576">tpv24-surface_cell/mesh0/u.bin</DataItem>
      (...)

```
Quite unexpectedly, loading tpv24-surface_cell/mesh0/connect.bin with myData = np.fromfile(fid, dtype=data_type) and reshaping, gives me an array of (1048576, 3) instead of (28240, 3). I think there are some incoherencies between the xdmf file and the binary file.

Anyway, I fixed this problem in the module by trimming the array after having read it, but this might be something to fix in SeisSol. (note that paraview does not complain).

