### PR TITLE
fix_readNElements for reading seissol mesh

### DIFF
--- a/seissolxmdf/seissolxdmf/__init__.py
+++ b/seissolxmdf/seissolxdmf/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmf import *
-__version__ = '0.0.7'
+__version__ = '0.0.8'

--- a/seissolxmdf/seissolxdmf/seissolxdmf.py
+++ b/seissolxmdf/seissolxdmf/seissolxdmf.py
@@ -159,13 +159,15 @@ class seissolxdmf:
     def ReadNElements(self):
         """ read number of cell elements of the mesh """
         root = self.tree.getroot()
-        for Property in root.findall("Domain/Grid/Grid/Topology"):
-            path = Property.get("Reference")
-            if path is None:
-                return int(Property.get("NumberOfElements"))
-            else:
-                ref = tree.xpath(path)[0]
-                return int(ref.get("NumberOfElements"))
+        list_possible_location = ["Domain/Grid/Grid/Topology", "Domain/Grid/Topology"]
+        for location in list_possible_location:
+            for Property in root.findall(location):
+                path = Property.get("Reference")
+                if path is None:
+                    return int(Property.get("NumberOfElements"))
+                else:
+                    ref = tree.xpath(path)[0]
+                    return int(ref.get("NumberOfElements"))
         raise NameError("nElements could not be determined")
 
     def ReadTimeStep(self):


### PR DESCRIPTION
The newest seissolxdmf call by initialisation readNElements. 
But this did not work for seissol meshes, because the structure is for example:

```
<?xml version="1.0" ?>
<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
<Xdmf Version="2.0">
 <Domain>
  <Grid Name="puml mesh" GridType="Uniform">
   <Geometry name="geo" GeometryType="XYZ" NumberOfElements="190894">
    <DataItem NumberType="Float" Precision="8" Format="HDF" Dimensions="190894 3">tpv33_half_sym:/geometry</DataItem>
   </Geometry>
   <Topology TopologyType="Tetrahedron" NumberOfElements="1159406">
    <DataItem NumberType="Int" Precision="8" Format="HDF" Dimensions="1159406 4">tpv33_half_sym:/connect</DataItem>
   </Topology>
   <Attribute Name="group" Center="Cell">
    <DataItem  NumberType="Int" Precision="4" Format="HDF" Dimensions="1159406">tpv33_half_sym:/group</DataItem>
   </Attribute>
   <Attribute Name="boundary" Center="Cell">
    <DataItem NumberType="Int" Precision="4" Format="HDF" Dimensions="1159406">tpv33_half_sym:/boundary</DataItem>
   </Attribute>
  </Grid>
 </Domain>
</Xdmf>
```
(NumberOfElements is at Domain/Grid/Topology and not Domain/Grid/Grid/Topology)
I, therefore, update the reader to work with this kind of file.