### PR TITLE
seissolxdmfwriter: allow writing in raw format and change interface

### DIFF
--- a/seissolxdmf/README.md
+++ b/seissolxdmf/README.md
@@ -13,6 +13,8 @@ nElements = sx.ReadNElements()
 dt = sx.ReadTimeStep()
 # Read number of time steps
 ndt = sx.ReadNdt()
+# Returns a list of the output time values
+outputTimes = sx.ReadTimes()
 # load geometry array as a numpy array of shape ((nodes, 3))
 geom = sx.ReadGeometry()
 # load connectivity array as a numpy array of shape ((nElements, 3 or 4))

--- a/seissolxdmf/seissolxdmf/__init__.py
+++ b/seissolxdmf/seissolxdmf/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmf import *
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/seissolxdmf/seissolxdmf/seissolxdmf.py
+++ b/seissolxdmf/seissolxdmf/seissolxdmf.py
@@ -168,6 +168,14 @@ class seissolxdmf:
         else:
             return ndt
 
+    def ReadTimes(self):
+        """returns the list of output times written in the file"""
+        root = self.tree.getroot()
+        outputTimes = []
+        for Property in root.findall("Domain/Grid/Grid/Time"):
+            outputTimes.append(float(Property.get("Value")))
+        return outputTimes
+
     def ReadNElements(self):
         """ read number of cell elements of the mesh """
         root = self.tree.getroot()

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -13,12 +13,14 @@ sx = sx.seissolxdmf(fn)
 geom = sx.ReadGeometry()
 connect = sx.ReadConnect()
 dt = sx.ReadTimeStep()
+outputTimes = sx.ReadTimes()
+
 SRs = sx.ReadData("SRs")
 SRd = sx.ReadData("SRs")
 SR = np.sqrt(SRs**2 + SRd**2)
 
 # Write the 0,4 and 8th times steps of array SRs and SR in SRtest-fault.xdmf/SRtest-fault.h5
-dictTime = {dt * i: i for i in [0, 4, 8]}
+dictTime = {outputTimes[i]: i for i in [0, 4, 8]}
 sxw.write(
     "test-fault",
     geom,

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -1,6 +1,6 @@
 seissolxdmfwriter
-===============
-Functions to write seissol outputs readable by paraview.
+==================
+A python module to write seissol outputs readable by paraview.
 
 ```python
 import seissolxdmfwriter as sxw
@@ -18,15 +18,15 @@ SRd = sx.ReadData("SRs")
 SR = np.sqrt(SRs**2 + SRd**2)
 
 # Write the 0,4 and 8th times steps of array SRs and SR in SRtest-fault.xdmf/SRtest-fault.h5
-sxw.write_seissol_output(
+dictTime = {dt * i: i for i in [0, 4, 8]}
+sxw.write(
     "test-fault",
     geom,
     connect,
-    ["SRs", "SR"],
-    [SRs, SR],
-    dt,
-    [0, 4, 8],
+    {"SRs": SRs, "SR": SR},
+    dictTime,
     reduce_precision=True,
     to_hdf5=True,
 )
 ```
+

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -1,5 +1,5 @@
 seissolxdmfwriter
-==================
+=================
 A python module to write seissol outputs readable by paraview.
 
 ```python
@@ -26,7 +26,7 @@ sxw.write(
     {"SRs": SRs, "SR": SR},
     dictTime,
     reduce_precision=True,
-    to_hdf5=True,
+    backend="hdf5",
 )
 ```
 

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -5,16 +5,28 @@ Functions to write seissol outputs readable by paraview.
 ```python
 import seissolxdmfwriter as sxw
 import seissolxdmf as sx
-fn = 'test-fault.xdmf'
+import numpy as np
+
+fn = "test-fault.xdmf"
 # Read data from input file using seissolxdmf
 sx = sx.seissolxdmf(fn)
 geom = sx.ReadGeometry()
 connect = sx.ReadConnect()
 dt = sx.ReadTimeStep()
-SRs = sx.ReadData('SRs')
-SRd = sx.ReadData('SRs')
+SRs = sx.ReadData("SRs")
+SRd = sx.ReadData("SRs")
 SR = np.sqrt(SRs**2 + SRd**2)
 
 # Write the 0,4 and 8th times steps of array SRs and SR in SRtest-fault.xdmf/SRtest-fault.h5
-sxw.write_seissol_output('test-fault', geom, connect, ['SRs', 'SR'], [SRs, SR], dt, [0, 4, 8])
+sxw.write_seissol_output(
+    "test-fault",
+    geom,
+    connect,
+    ["SRs", "SR"],
+    [SRs, SR],
+    dt,
+    [0, 4, 8],
+    reduce_precision=True,
+    to_hdf5=True,
+)
 ```

--- a/seissolxdmfwriter/seissolxdmfwriter/__init__.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmfwriter import *
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -213,7 +213,9 @@ def write_seissol_output(
     lidt: list of time steps to be written
     reduce_precision: convert double to float and i64 to i32 if True
     """
-    print("Warning: write_seissol_output is deprecated. Please use write instead")
+    from warnings import warn
+
+    warn("write_seissol_output is deprecated. Please use write instead")
     nNodes = xyz.shape[0]
     nCells, node_per_element = connect.shape
     dictData = {}


### PR DESCRIPTION
- allow writing in raw format in seissolxdmfwriter

  I need this feature because of incompatibilities between h5py and easi python modules:
  the easi python module is linked with netcdf/mpi module and the sequential h5py module because it is linked with netcdf/sequential. Then if you load both module in the same script you get an error.
  
  Yet, a natural use of the easi module is to parse fault input data and write them with seissolxdmfwriter for later plotting with paraview.

-  change interface of seissolxdmfwriter (see readme)
  I think it make more sense to pass a dictionnary.
  Also I now pass the time as dictionnary: this allows extracting extracts of seissol outputs.
  e.g. I first extract from file0 time 0. 1.0 10. to file1.
  Then I can now extract time 1.0 and 10.0 to file2 and keep accurate time information. 
  (note that the old interface can still be used, but is marked deprecated)
