### PR TITLE
seissolxdmfwriter: bug fixes and more input checks

### DIFF
--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -16,7 +16,7 @@ dt = sx.ReadTimeStep()
 outputTimes = sx.ReadTimes()
 
 SRs = sx.ReadData("SRs")
-SRd = sx.ReadData("SRs")
+SRd = sx.ReadData("SRd")
 SR = np.sqrt(SRs**2 + SRd**2)
 
 # Write the 0,4 and 8th times steps of array SRs and SR in SRtest-fault.xdmf/SRtest-fault.h5

--- a/seissolxdmfwriter/seissolxdmfwriter/__init__.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmfwriter import *
-__version__ = '0.2.1'
+__version__ = '0.2.2'


### PR DESCRIPTION
- The meshwriter was not working because node_per_element was not defined and because there were 2 issues in the alignement of the code (I should have tested that...).
- The timehistory writer was not working if there is only one time step in the array.
- Added a check that the max index in the dictTime has to be smaller than the length of the dataArray.