### PR TITLE
adding seissol_output_extractor to seissolxdmfwriter

### DIFF
--- a/seissolxdmf/README.md
+++ b/seissolxdmf/README.md
@@ -9,6 +9,10 @@ fn = 'test-fault.xdmf'
 sx = seissolxdmf.seissolxdmf(fn)
 # Number of cells
 nElements = sx.ReadNElements()
+# Number of vertices
+nNodes = sx.ReadNNodes()
+# Number of nodes per elements
+nodesPerElement = sx.ReadNodesPerElement()
 # Read time step
 dt = sx.ReadTimeStep()
 # Read number of time steps

--- a/seissolxdmf/seissolxdmf/__init__.py
+++ b/seissolxdmf/seissolxdmf/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmf import *
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/seissolxdmf/seissolxdmf/seissolxdmf.py
+++ b/seissolxdmf/seissolxdmf/seissolxdmf.py
@@ -81,7 +81,7 @@ class seissolxdmf:
 
         fid = open(absolute_path, "r")
         if oneDtMem:
-            assert idt < self.ndt
+            assert idt < self.ndt, f"{idt} < {self.ndt}"
             fid.seek((idt * MemDimension + firstElement) * data_prec, os.SEEK_SET)
             myData = np.fromfile(fid, dtype=data_type, count=nchunk)
         else:

--- a/seissolxdmf/seissolxdmf/seissolxdmf.py
+++ b/seissolxdmf/seissolxdmf/seissolxdmf.py
@@ -176,19 +176,35 @@ class seissolxdmf:
             outputTimes.append(float(Property.get("Value")))
         return outputTimes
 
-    def ReadNElements(self):
-        """ read number of cell elements of the mesh """
+    def ReadField(self, field, list_possible_location):
         root = self.tree.getroot()
-        list_possible_location = ["Domain/Grid/Grid/Topology", "Domain/Grid/Topology"]
         for location in list_possible_location:
             for Property in root.findall(location):
                 path = Property.get("Reference")
-                if path is None:
-                    return int(Property.get("NumberOfElements"))
+                if not path:
+                    return Property.get(field)
                 else:
                     ref = tree.xpath(path)[0]
-                    return int(ref.get("NumberOfElements"))
-        raise NameError("nElements could not be determined")
+                    return ref.get(field)
+        raise NameError(f"{field} not found in {list_possible_location}")
+
+    def ReadNElements(self):
+        """ read number of cell elements of the mesh """
+        list_possible_location = ["Domain/Grid/Grid/Topology", "Domain/Grid/Topology"]
+        field  = self.ReadField("NumberOfElements", list_possible_location)
+        return int(field)
+
+    def ReadNNodes(self):
+        """ read number of vertex of the mesh """
+        list_possible_location = ["Domain/Grid/Grid/Geometry", "Domain/Grid/Geometry"]
+        field  = self.ReadField("NumberOfElements", list_possible_location)
+        return int(field)
+
+    def ReadNodesPerElement(self):
+        """ read number of nodes per elements of the mesh """
+        list_possible_location = ["Domain/Grid/Grid/Topology/DataItem", "Domain/Grid/Topology/DataItem"]
+        field  = self.ReadField("Dimensions", list_possible_location)
+        return int(field.split()[1])
 
     def ReadAvailableDataFields(self):
         """ read all available data fields, e.g. SRs or P_n """

--- a/seissolxdmf/seissolxdmf/seissolxdmf.py
+++ b/seissolxdmf/seissolxdmf/seissolxdmf.py
@@ -176,35 +176,35 @@ class seissolxdmf:
             outputTimes.append(float(Property.get("Value")))
         return outputTimes
 
-    def ReadField(self, field, list_possible_location):
+    def ReadAttributeValue(self, attribute, list_possible_location):
         root = self.tree.getroot()
         for location in list_possible_location:
             for Property in root.findall(location):
                 path = Property.get("Reference")
                 if not path:
-                    return Property.get(field)
+                    return Property.get(attribute)
                 else:
                     ref = tree.xpath(path)[0]
-                    return ref.get(field)
-        raise NameError(f"{field} not found in {list_possible_location}")
+                    return ref.get(attribute)
+        raise NameError(f"{attribute} not found in {list_possible_location}")
 
     def ReadNElements(self):
         """ read number of cell elements of the mesh """
         list_possible_location = ["Domain/Grid/Grid/Topology", "Domain/Grid/Topology"]
-        field  = self.ReadField("NumberOfElements", list_possible_location)
-        return int(field)
+        value  = self.ReadAttributeValue("NumberOfElements", list_possible_location)
+        return int(value)
 
     def ReadNNodes(self):
         """ read number of vertex of the mesh """
         list_possible_location = ["Domain/Grid/Grid/Geometry", "Domain/Grid/Geometry"]
-        field  = self.ReadField("NumberOfElements", list_possible_location)
-        return int(field)
+        value  = self.ReadAttributeValue("NumberOfElements", list_possible_location)
+        return int(value)
 
     def ReadNodesPerElement(self):
         """ read number of nodes per elements of the mesh """
         list_possible_location = ["Domain/Grid/Grid/Topology/DataItem", "Domain/Grid/Topology/DataItem"]
-        field  = self.ReadField("Dimensions", list_possible_location)
-        return int(field.split()[1])
+        value  = self.ReadAttributeValue("Dimensions", list_possible_location)
+        return int(value.split()[1])
 
     def ReadAvailableDataFields(self):
         """ read all available data fields, e.g. SRs or P_n """

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -46,3 +46,4 @@ sxw.write_from_seissol_output(
 
 ```
 
+The module also encapsulates `seissol_output_extractor.py`, which can be used to extract and process data from SeisSol output files, allowing selection of variables, time steps, spatial ranges, and output format.

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -35,7 +35,7 @@ sxw.write(
 # the memory requirements
 
 sxw.write_from_seissol_output(
-    'test-fault-raw-sx',
+    'test-fault-sx',
     fn,
     ['SRs', 'SRd','fault-tag', 'partition'],
     [3,4],

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -46,4 +46,9 @@ sxw.write_from_seissol_output(
 
 ```
 
-The module also encapsulates `seissol_output_extractor.py`, which can be used to extract and process data from SeisSol output files, allowing selection of variables, time steps, spatial ranges, and output format.
+The module also encapsulates `seissol_output_extractor`, which can be used to extract and process data from SeisSol output files, allowing selection of variables, time steps, spatial ranges, and output format.
+Here is an example of use:
+
+```bash
+seissol_output_extractor test-fault.xdmf --time "i2,i4" --variable PSR Vr partition
+```

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -50,5 +50,7 @@ The module also encapsulates `seissol_output_extractor`, which can be used to ex
 Here is an example of use:
 
 ```bash
-seissol_output_extractor test-fault.xdmf --time "i2,i4" --variable PSR Vr partition
+# extracts PSR, Vr and partition, at 2nd and 4th time steps and at simulation time 0.5, from test-fault.xdmf and write into test_new-fault.xdmf
+# use seissol_output_extractor --h for additionnal info about the arguments
+seissol_output_extractor test-fault.xdmf --time "i2,i4,0.5" --variable PSR Vr partition --add2prefix "_new"
 ```

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -30,5 +30,19 @@ sxw.write(
     reduce_precision=True,
     backend="hdf5",
 )
+
+# Finally, the module can be use to write data directly from seissolxdmf, limiting
+# the memory requirements
+
+sxw.write_from_seissol_output(
+    'test-fault-raw-sx',
+    fn,
+    ['SRs', 'SRd','fault-tag', 'partition'],
+    [3,4],
+    reduce_precision=True,
+    backend="hdf5",
+    compression_level=4,
+)
+
 ```
 

--- a/seissolxdmfwriter/seissolxdmfwriter/__init__.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmfwriter import *
-__version__ = '0.2.2'
+__version__ = '0.2.3'

--- a/seissolxdmfwriter/seissolxdmfwriter/__init__.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmfwriter import *
-__version__ = '0.2.3'
+__version__ = '0.3.0'

--- a/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+import os
+import os.path
+import seissolxdmf
+import seissolxdmfwriter as sxw
+import numpy as np
+import argparse
+
+
+def generate_new_prefix(prefix, append2prefix):
+    prefix = os.path.basename(prefix)
+    lsplit = prefix.split("-")
+    if len(lsplit) > 1:
+        if lsplit[-1] in ["surface", "low", "fault"]:
+            prefix0 = "-".join(lsplit[0:-1])
+            prefix_new = prefix0 + append2prefix + "-" + lsplit[-1]
+        else:
+            prefix_new = prefix + append2prefix
+    else:
+        prefix_new = prefix + append2prefix
+    return prefix_new
+
+
+parser = argparse.ArgumentParser(
+    description="Extracts and processes data from SeisSol output files"
+)
+parser.add_argument("xdmfFilename", help="SeisSol XDMF output filename")
+parser.add_argument(
+    "--add2prefix",
+    help="string to append to the prefix in the new file",
+    type=str,
+    default="_resampled",
+)
+parser.add_argument(
+    "--variables",
+    nargs="+",
+    metavar="variables",
+    help="Names of variables to extract (e.g. SRs or all)",
+    default=["all"],
+)
+parser.add_argument(
+    "--precision",
+    type=str,
+    choices=["float", "double"],
+    default="float",
+    help="precision of the data in the output file",
+)
+parser.add_argument(
+    "--backend",
+    type=str,
+    choices=["hdf5", "raw"],
+    default="hdf5",
+    help="backend used: raw (.bin file), hdf5 (.h5)",
+)
+parser.add_argument(
+    "--compression",
+    type=int,
+    default=4,
+    help="compression level (for hdf5 format only)",
+)
+parser.add_argument(
+    "--time",
+    nargs=1,
+    default=["i:"],
+    help=(
+        "simulation time or steps to extract, separated by ','. prepend a i for a step,"
+        " or a python slice notation. E.g. 45.0,i2,i4:10:2,i-1 will extract a snapshot"
+        " at simulation time 45.0, the 2nd time step, and time steps 4,6, 8 and the"
+        " last time step"
+    ),
+)
+
+parser.add_argument(
+    "--xRange",
+    nargs=2,
+    metavar=("xmin", "xmax"),
+    help="filter cells with x center coordinates in range xmin xmax",
+    type=float,
+)
+parser.add_argument(
+    "--yRange",
+    nargs=2,
+    metavar=("ymin", "ymax"),
+    help="filter cells with y center coordinates in range ymin ymax",
+    type=float,
+)
+parser.add_argument(
+    "--zRange",
+    nargs=2,
+    metavar=("zmin", "zmax"),
+    help="filter cells with z center coordinates in range zmin zmax",
+    type=float,
+)
+args = parser.parse_args()
+
+
+class SeissolxdmfExtended(seissolxdmf.seissolxdmf):
+    def ComputeTimeIndices(self, at_time):
+        """retrive list of time index in file"""
+        outputTimes = np.array(sx.ReadTimes())
+        idsReadTimes = list(range(0, len(outputTimes)))
+        lidt = []
+        for oTime in at_time:
+            if not oTime.startswith("i"):
+                idsClose = np.where(np.isclose(outputTimes, float(oTime), atol=0.0001))
+                if not len(idsClose[0]):
+                    print(f"t={oTime} not found in {sx.xdmfFilename}")
+                else:
+                    lidt.append(idsClose[0][0])
+            else:
+                sslice = oTime[1:]
+                if ":" in sslice or sslice == "-1":
+                    parts = sslice.split(":")
+                    startstopstep = [None for i in range(3)]
+                    for i, part in enumerate(parts):
+                        startstopstep[i] = int(part) if part else None
+                    lidt.extend(
+                        idsReadTimes[
+                            startstopstep[0] : startstopstep[1] : startstopstep[2]
+                        ]
+                    )
+                else:
+                    lidt.append(int(sslice))
+        return sorted(list(set(lidt)))
+
+    def ReadData(self, dataName, idt=-1):
+        if dataName == "SR" and "SR" not in sx.ReadAvailableDataFields():
+            SRs = super().ReadData("SRs", idt)
+            SRd = super().ReadData("SRd", idt)
+            return np.sqrt(SRs**2 + SRd**2)
+        else:
+            return super().ReadData(dataName, idt)
+
+
+sx = SeissolxdmfExtended(args.xdmfFilename)
+spatial_filtering = (args.xRange or args.yRange) or args.zRange
+
+if spatial_filtering:
+    xyz = sx.ReadGeometry()
+    connect = sx.ReadConnect()
+    print("Warning: spatial filtering significantly slows down this script")
+    ids = range(0, sx.nElements)
+    xyzc = (xyz[connect[:, 0], :] + xyz[connect[:, 1], :] + xyz[connect[:, 2], :]) / 3.0
+
+    def filter_cells(coords, filter_range):
+        m = 0.5 * (filter_range[0] + filter_range[1])
+        d = 0.5 * (filter_range[1] - filter_range[0])
+        return np.where(np.abs(coords[:] - m) < d)[0]
+
+    if args.xRange:
+        id0 = filter_cells(xyzc[:, 0], args.xRange)
+        ids = np.intersect1d(ids, id0) if len(ids) else id0
+    if args.yRange:
+        id0 = filter_cells(xyzc[:, 1], args.yRange)
+        ids = np.intersect1d(ids, id0) if len(ids) else id0
+    if args.zRange:
+        id0 = filter_cells(xyzc[:, 2], args.zRange)
+        ids = np.intersect1d(ids, id0) if len(ids) else id0
+
+    if len(ids):
+        nElements = ids.shape[0]
+        if nElements != sx.nElements:
+            print(f"extracting {nElements} cells out of {sx.nElements}")
+        else:
+            spatial_filtering = False
+    else:
+        raise ValueError("all elements are outside filter range")
+
+if not spatial_filtering:
+    ids = slice(None)
+
+indices = sx.ComputeTimeIndices(args.time[0].split(","))
+
+prefix = os.path.splitext(args.xdmfFilename)[0]
+prefix_new = generate_new_prefix(prefix, args.add2prefix)
+
+# Write data items
+if args.variables[0] == "all":
+    args.variables = sorted(sx.ReadAvailableDataFields())
+    print(f"args.variables was set to all and now contains {args.variables}")
+
+sxw.write_from_seissol_output(
+    prefix_new,
+    args.xdmfFilename,
+    args.variables,
+    indices,
+    reduce_precision=True,
+    backend=args.backend,
+    compression_level=args.compression,
+    filtered_cells=ids,
+)

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
-
+from tqdm import tqdm
+import sys
 
 known_1d_arrays = ["location-flag", "fault-tag", "partition", "clustering"]
 
@@ -208,7 +209,12 @@ def write_data_from_seissolxdmf(
                 my_array = read_non_temporal(sx, ar_name, filtered_cells)
                 write_one_arr_hdf5(h5f, ar_name, my_array, compression_options)
             for ar_name in array_names:
-                for i, idt in enumerate(time_indices):
+                for i, idt in tqdm(
+                    enumerate(time_indices),
+                    file=sys.stdout,
+                    desc=ar_name,
+                    dynamic_ncols=False,
+                ):
                     if i == 0:
                         h5f.create_dataset(
                             f"/{ar_name}",
@@ -232,7 +238,12 @@ def write_data_from_seissolxdmf(
                 my_array.tofile(fid)
         for ar_name in array_names:
             with open(f"{prefix}/{ar_name}.bin", "wb") as fid:
-                for i, idt in enumerate(time_indices):
+                for i, idt in tqdm(
+                    enumerate(time_indices),
+                    file=sys.stdout,
+                    desc=ar_name,
+                    dynamic_ncols=False,
+                ):
                     my_array = sx.ReadData(ar_name, idt)[filtered_cells]
                     if my_array.shape[0] == 0:
                         print(
@@ -374,7 +385,7 @@ def write(
         dicDataNonTemporal[name] = dictData.pop(name)
 
     if backend not in ("hdf5", "raw"):
-        raise ValueError("Invalid backend. Must be 'hdf5' or 'raw'.")
+        raise ValueError(f"Invalid backend {backend}. Must be 'hdf5' or 'raw'.")
     if compression_level < 0 or compression_level > 9:
         raise ValueError("compression_level has to be in 0-9")
 
@@ -447,7 +458,7 @@ def write_from_seissol_output(
     import seissolxdmf as sx
 
     if backend not in ("hdf5", "raw"):
-        raise ValueError("Invalid backend. Must be 'hdf5' or 'raw'.")
+        raise ValueError(f"Invalid backend {backend}. Must be 'hdf5' or 'raw'.")
     if compression_level < 0 or compression_level > 9:
         raise ValueError("compression_level has to be in 0-9")
 

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -3,7 +3,7 @@ import os
 from tqdm import tqdm
 import sys
 
-known_1d_arrays = ["location-flag", "fault-tag", "partition", "clustering"]
+known_1d_arrays = ["locationFlag", "fault-tag", "partition", "clustering"]
 
 
 def dataLocation(prefix, name, backend):

--- a/seissolxdmfwriter/setup.py
+++ b/seissolxdmfwriter/setup.py
@@ -23,11 +23,16 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/SeisSol/Visualization/seissolxdmfwriter",
     packages=setuptools.find_packages(),
+    entry_points={
+        'console_scripts': [
+            'seissol_output_extractor = seissolxdmfwriter.seissol_output_extractor:main',
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["numpy", "h5py"],
+    install_requires=["numpy", "h5py","seissolxdmf>=0.1.2"],
 )


### PR DESCRIPTION
(sorry for another PR of seissolxdmfwriter).
I thought that I could take advantage of the latest change in seissolxdmfwriter to rewrite in few lines this script:
https://github.com/SeisSol/SeisSol/blob/master/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py

But I realized in the process that  I would need to modify seissolxdmfwriter because  extractDataFromUnstructuredOutput.py reads and writes on the fly (to avoid loading 2Tb of memory all at one).

Anyway, I ended up doing that and fixed a few bugs in the process.

The new extractor (seissol_output_extractor) will be shipped with the module, which is quite convenient.
Compared to extractDataFromUnstructuredOutput, it supports writing partition, fault-tag, locationFlag (and write them only once).
It enables compression by default (because of that is is a bit slower than extractDataFromUnstructuredOutput.py).
Without compression, it is still slightly slower (nothing very significant).
It has a nice tqdm interface (maybe less nice when writting to a log).