### PR TITLE
seissolxdm/seissolxdmfwriter: bugfixes

### DIFF
--- a/seissolxdmf/seissolxdmf/__init__.py
+++ b/seissolxdmf/seissolxdmf/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmf import *
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/seissolxdmf/seissolxdmf/seissolxdmf.py
+++ b/seissolxdmf/seissolxdmf/seissolxdmf.py
@@ -237,6 +237,10 @@ class seissolxdmf:
             filename, hdf5var = splitArgs
             myData = self.ReadHdf5DatasetChunk(path + filename, hdf5var, 0, MemDimension)
         else:
+            # The Dimensions of the 1D arrays (e.g. partition) in the xdmf files
+            # are not not accounting for potential 0 padding (bug in xdmfwriter?).
+            # Therefore, we precise that there is only one "time-step" to read at location 0
+            # by setting idt=0
             filename = dataLocation
             myData = self.ReadSimpleBinaryFile(path + dataLocation, nElements, data_prec, isInt, 0)
         return myData

--- a/seissolxdmf/seissolxdmf/seissolxdmf.py
+++ b/seissolxdmf/seissolxdmf/seissolxdmf.py
@@ -238,7 +238,7 @@ class seissolxdmf:
             myData = self.ReadHdf5DatasetChunk(path + filename, hdf5var, 0, MemDimension)
         else:
             filename = dataLocation
-            myData = self.ReadSimpleBinaryFile(path + dataLocation, nElements, data_prec, isInt)
+            myData = self.ReadSimpleBinaryFile(path + dataLocation, nElements, data_prec, isInt, 0)
         return myData
 
     def ReadPartition(self):

--- a/seissolxdmfwriter/README.md
+++ b/seissolxdmfwriter/README.md
@@ -36,7 +36,7 @@ sxw.write(
 
 sxw.write_from_seissol_output(
     'test-fault-sx',
-    fn,
+    sx,
     ['SRs', 'SRd','fault-tag', 'partition'],
     [3,4],
     reduce_precision=True,

--- a/seissolxdmfwriter/seissolxdmfwriter/__init__.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmfwriter import *
-__version__ = '0.3.0'
+__version__ = '0.4.0'

--- a/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
@@ -188,6 +188,13 @@ def main():
         args.variables = sorted(sx.ReadAvailableDataFields())
         print(f"args.variables was set to all and now contains {args.variables}")
 
+    if args.backend == "hdf5" and args.compression > 0:
+        print(
+            "Writing hdf5 output with compression enabled"
+            f" (compression_level={args.compression}). Use --compression=0 if you want"
+            " to speed-up data extraction."
+        )
+
     sxw.write_from_seissol_output(
         prefix_new,
         sx,

--- a/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
@@ -131,6 +131,12 @@ class SeissolxdmfExtended(seissolxdmf.seissolxdmf):
         else:
             return super().ReadData(dataName, idt)
 
+    def GetDataLocationPrecisionMemDimension(self, dataName):
+        if dataName == "SR" and "SR" not in self.ReadAvailableDataFields():
+            return super().GetDataLocationPrecisionMemDimension("SRs")
+        else:
+            return super().GetDataLocationPrecisionMemDimension(dataName)
+
 
 def main():
     sx = SeissolxdmfExtended(args.xdmfFilename)
@@ -184,7 +190,7 @@ def main():
 
     sxw.write_from_seissol_output(
         prefix_new,
-        args.xdmfFilename,
+        sx,
         args.variables,
         indices,
         reduce_precision=True,

--- a/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
@@ -5,6 +5,7 @@ import seissolxdmf
 import seissolxdmfwriter as sxw
 import numpy as np
 import argparse
+from warnings import warn
 
 
 def generate_new_prefix(prefix, append2prefix):
@@ -145,7 +146,7 @@ def main():
     if spatial_filtering:
         xyz = sx.ReadGeometry()
         connect = sx.ReadConnect()
-        print("Warning: spatial filtering significantly slows down this script")
+        warn("spatial filtering significantly slows down this script")
         ids = range(0, sx.nElements)
         xyzc = (
             xyz[connect[:, 0], :] + xyz[connect[:, 1], :] + xyz[connect[:, 2], :]
@@ -191,8 +192,8 @@ def main():
     if args.backend == "hdf5" and args.compression > 0:
         print(
             "Writing hdf5 output with compression enabled"
-            f" (compression_level={args.compression}). Use --compression=0 if you want"
-            " to speed-up data extraction."
+            f" (compression_level={args.compression}). \n"
+            "Use --compression=0 if you want to speed-up data extraction."
         )
 
     sxw.write_from_seissol_output(

--- a/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissol_output_extractor.py
@@ -29,7 +29,7 @@ parser.add_argument(
     "--add2prefix",
     help="string to append to the prefix in the new file",
     type=str,
-    default="_resampled",
+    default="_extracted",
 )
 parser.add_argument(
     "--variables",

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -195,7 +195,7 @@ def write_data_from_seissolxdmf(
         elif ar_name == "connect":
             return sx.ReadConnect()[filtered_cells, :]
         else:
-            return sx.Read1dData(ar_name, sx.nElements, isInt=True)[:, filtered_cells]
+            return sx.Read1dData(ar_name, sx.nElements, isInt=True)[filtered_cells]
 
     nel = infer_n_elements(sx, filtered_cells)
     if backend == "hdf5":

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -215,6 +215,7 @@ def write_data_from_seissolxdmf(
                     desc=ar_name,
                     dynamic_ncols=False,
                 ):
+                    my_array = sx.ReadData(ar_name, idt)[filtered_cells]
                     if i == 0:
                         h5f.create_dataset(
                             f"/{ar_name}",
@@ -222,7 +223,6 @@ def write_data_from_seissolxdmf(
                             dtype=str(output_type(my_array, reduce_precision)),
                             **compression_options,
                         )
-                    my_array = sx.ReadData(ar_name, idt)[filtered_cells]
                     if my_array.shape[0] == 0:
                         print(
                             f"time step {idt} of {ar_name} is corrupted, replacing with 0s"
@@ -438,7 +438,7 @@ def write(
 
 def write_from_seissol_output(
     prefix,
-    input_file,
+    sx,
     var_names,
     time_indices,
     reduce_precision=False,
@@ -449,20 +449,16 @@ def write_from_seissol_output(
     """
     Write hdf5/xdmf files output, readable by ParaView from a seissolxdmf object
     prefix: file
-    input_file: filename of the seissol input
+    sx: seissolxdmf object
     var_names: list of variables to extract
     time_indices: list of times indices to extract
     reduce_precision: convert double to float and i64 to i32 if True
     backend: data format ("hdf5" or "raw")
     """
-    import seissolxdmf as sx
-
     if backend not in ("hdf5", "raw"):
         raise ValueError(f"Invalid backend {backend}. Must be 'hdf5' or 'raw'.")
     if compression_level < 0 or compression_level > 9:
         raise ValueError("compression_level has to be in 0-9")
-
-    sx = sx.seissolxdmf(input_file)
 
     non_temporal_array_names = ["geometry", "connect"]
     to_move = [name for name in var_names if name in known_1d_arrays]

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -90,6 +90,8 @@ def write_timeseries_xdmf(
     with open(prefix + ".xdmf", "w") as fid:
         fid.write(xdmf)
     print(f"done writing {prefix}.xdmf")
+    full_path = os.path.abspath(f"{prefix}.xdmf")
+    print(f"full path: {full_path}")
 
 
 def write_mesh_xdmf(
@@ -135,6 +137,8 @@ def write_mesh_xdmf(
     with open(prefix + ".xdmf", "w") as fid:
         fid.write(xdmf)
     print(f"done writing {prefix}.xdmf")
+    full_path = os.path.abspath(f"{prefix}.xdmf")
+    print(f"full path: {full_path}")
 
 
 def output_type(input_array, reduce_precision):

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -42,6 +42,7 @@ def write_timeseries_xdmf(
     reduce_precision,
     backend,
 ):
+    bn_prefix = os.path.basename(prefix)
     data_format = "HDF" if backend == "hdf5" else "Binary"
     lDataName = list(dictDataTypes.keys())
     lDataTypes = list(dictDataTypes.values())
@@ -50,8 +51,8 @@ def write_timeseries_xdmf(
 <!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
 <Xdmf Version="2.0">
  <Domain>"""
-    geometry_location = dataLocation(prefix, "geometry", backend)
-    connect_location = dataLocation(prefix, "connect", backend)
+    geometry_location = dataLocation(bn_prefix, "geometry", backend)
+    connect_location = dataLocation(bn_prefix, "connect", backend)
 
     for i, ctime in enumerate(timeValues):
         xdmf += f"""
@@ -65,7 +66,7 @@ def write_timeseries_xdmf(
     </Geometry>
     <Time Value="{ctime}"/>"""
         for k, dataName in enumerate(list(dictDataTypes.keys())):
-            data_location = dataLocation(prefix, dataName, backend)
+            data_location = dataLocation(bn_prefix, dataName, backend)
             prec, number_type = dictDataTypes[dataName]
             if dataName in known_1d_arrays:
                 xdmf += f"""
@@ -103,6 +104,7 @@ def write_mesh_xdmf(
     reduce_precision,
     backend,
 ):
+    bn_prefix = os.path.basename(prefix)
     data_format = "HDF" if backend == "hdf5" else "Binary"
     lDataName = list(dictDataTypes.keys())
     lDataTypes = list(dictDataTypes.values())
@@ -111,8 +113,8 @@ def write_mesh_xdmf(
 <!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
 <Xdmf Version="2.0">
  <Domain>"""
-    geometry_location = dataLocation(prefix, "geometry", backend)
-    connect_location = dataLocation(prefix, "connect", backend)
+    geometry_location = dataLocation(bn_prefix, "geometry", backend)
+    connect_location = dataLocation(bn_prefix, "connect", backend)
 
     xdmf += f"""
   <Grid Name="puml mesh" GridType="Uniform">
@@ -123,7 +125,7 @@ def write_mesh_xdmf(
      <DataItem NumberType="Float" Precision="8" Format="{data_format}" Dimensions="{nNodes} 3">{geometry_location}</DataItem>
     </Geometry>"""
     for k, dataName in enumerate(list(dictDataTypes.keys())):
-        data_location = dataLocation(prefix, dataName, backend)
+        data_location = dataLocation(bn_prefix, dataName, backend)
         prec, number_type = dictDataTypes[dataName]
         xdmf += f"""
     <Attribute Name="{dataName}" Center="Cell">

--- a/seissolxdmfwriter/setup.py
+++ b/seissolxdmfwriter/setup.py
@@ -34,5 +34,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["numpy", "h5py","seissolxdmf>=0.1.2"],
+    install_requires=["numpy", "h5py","seissolxdmf>=0.1.2", "tqdm"],
 )


### PR DESCRIPTION
- The extractor was not working with SR (computed from SRs and SRd), because the derived seissolxdmf was not passed to seissolxdmdwriter (and GetDataLocationPrecisionMemDimension needed to be specialized as well but was not). This required a change of the interface, so I increased version number of 0.4.0.
- seissolxdmf was not able to read a 1D array (e.g. partition, fault-tag) when the array was padded.
- seissolxdmfwriter was not working properly when specifiying a path in the prefix (in this case the basename should be written in the xdmf, to allow opening the file from any directory).
- dependency to tqdm is added.
- other bug fixes.