### PR TITLE
fix corrupted time-step for hdf5

### DIFF
--- a/seissolxdmfwriter/seissolxdmfwriter/__init__.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/__init__.py
@@ -1,2 +1,2 @@
 from .seissolxdmfwriter import *
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
+++ b/seissolxdmfwriter/seissolxdmfwriter/seissolxdmfwriter.py
@@ -221,7 +221,13 @@ def write_data_from_seissolxdmf(
                     desc=ar_name,
                     dynamic_ncols=False,
                 ):
-                    my_array = sx.ReadData(ar_name, idt)[filtered_cells]
+                    try:
+                        my_array = sx.ReadData(ar_name, idt)[filtered_cells]
+                    except IndexError:
+                        print(
+                            f"time step {idt} of {ar_name} is corrupted, replacing with 0s"
+                        )
+                        my_array = np.zeros(nel)
                     if i == 0:
                         h5f.create_dataset(
                             f"/{ar_name}",
@@ -233,7 +239,7 @@ def write_data_from_seissolxdmf(
                         print(
                             f"time step {idt} of {ar_name} is corrupted, replacing with 0s"
                         )
-                        myData = np.zeros(nel)
+                        my_array = np.zeros(nel)
                     h5f[f"/{ar_name}"][i, :] = my_array[:]
         print(f"done writing {prefix}.h5")
     else:
@@ -255,7 +261,7 @@ def write_data_from_seissolxdmf(
                         print(
                             f"time step {idt} of {ar_name} is corrupted, replacing with 0s"
                         )
-                        myData = np.zeros(nel)
+                        my_array = np.zeros(nel)
                     if i == 0:
                         mydtype = output_type(my_array, reduce_precision)
                     my_array[:].astype(mydtype).tofile(fid)


### PR DESCRIPTION
Fix this kind of problem (when seissol when interrupted while writing a time step):
```python
di73yeq4@login01:/hppfs/scratch/0A/di73yeq4/2015-09-16_Mw8.3_Chile_us20003k7a> seissol_output_extractor output/dyn_B0.805_C0.192_R0.685-fault.xdmf --variable ASl --time "i-1"
Writing hdf5 output with compression enabled (compression_level=4). 
Use --compression=0 if you want to speed-up data extraction.
ASl: 0it [00:00, ?it/s]
Traceback (most recent call last):
  File "/dss/dsshome1/0A/di73yeq4/.local/bin/seissol_output_extractor", line 8, in <module>
    sys.exit(main())
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmfwriter/seissol_output_extractor.py", line 199, in main
    sxw.write_from_seissol_output(
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmfwriter/seissolxdmfwriter.py", line 486, in write_from_seissol_output
    write_data_from_seissolxdmf(
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmfwriter/seissolxdmfwriter.py", line 224, in write_data_from_seissolxdmf
    my_array = sx.ReadData(ar_name, idt)[filtered_cells]
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmfwriter/seissol_output_extractor.py", line 133, in ReadData
    return super().ReadData(dataName, idt)
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmf/seissolxdmf.py", line 258, in ReadData
    return self.ReadDataChunk(dataName, firstElement=0, nchunk=self.nElements, idt=idt)
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmf/seissolxdmf.py", line 273, in ReadDataChunk
    myData = self.ReadHdf5DatasetChunk(path + filename, hdf5var, firstElement, nchunk, idt)
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/seissolxdmf/seissolxdmf.py", line 36, in ReadHdf5DatasetChunk
    myData = h5f[hdf5var][idt, firstElement:lastElement]
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/dss/dsshome1/0A/di73yeq4/.local/lib/python3.8/site-packages/h5py/_hl/dataset.py", line 710, in __getitem__
    return self._fast_reader.read(args)
  File "h5py/_selector.pyx", line 351, in h5py._selector.Reader.read
  File "h5py/_selector.pyx", line 151, in h5py._selector.Selector.apply_args
IndexError: Index (140) out of range for (0-139)
```
+ fix wrong variable name (I renamed myData to my_array recently bug forgot to rename it here).